### PR TITLE
Add blocks support to mix

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ b({ without: false });  // 'button'
 b('icon').mix('another'); // 'button__icon another'
 b('icon').mix([ 'one', 'two' ); // 'button__icon one two'
 b('icon').mix({ one: true, two: false, three: true }); // 'button__icon one three'
+b('icon').mix(b); // 'button__icon button'
 
 // States
 // As SMACSS states: https://smacss.com/book/type-state

--- a/src/bem-cn.js
+++ b/src/bem-cn.js
@@ -137,14 +137,14 @@
 
 	/**
 	 * Static method mix() for callable instance
-	 * @param {String|Array|Object} className 'class'; ['one', 'two']; {one: true, two: false}
+	 * @param {String|Array|Object|block} className 'class'; ['one', 'two']; {one: true, two: false}; block('one')
 	 */
 	function mix(className) {
 		var context = copy(this),
 			classes;
 
 		if ( className ) {
-			if ( typeof className === 'string' ) {
+			if ( typeof className === 'string' || typeof className === 'function' ) {
 				classes = [ className ];
 			} else if ( Array.isArray(className) ) {
 				classes = className;

--- a/test/test.js
+++ b/test/test.js
@@ -95,6 +95,9 @@ describe('Callable block instance', function() {
 		should(
 			b.mix({ one: true, two: false, three: true }).toString()
 		).equal('parent one three');
+		should(
+			b.mix(b).toString()
+		).equal('parent parent');
 	});
 });
 


### PR DESCRIPTION
Up to v1.0.0 this code worked as expected:
```
var b1 = block('b1');
var b2 = block('b2');
b2().mix(b1('element')); // 'b2 b1__element'
```
#8 broke this functionality:
```
b2().mix(b1('element')); // 'b2 toStringfunction () { [native code] } splitfunction () { [native code] } mixfunction () { [native code] } statefunction () { [native code] }'
```
This PR restores it.