### PR TITLE
Added ability to specify ModifierValue separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,14 @@ b.state({ hidden: true, error: true }); // 'button is-hidden is-error'
 // Setup custom separators
 block.setup({
     el: '~~',
-    mod: '-'
+    mod: '--',
+    modValue: '-'
 });
 
 var b = block('block');
 
 b('element'); // 'block~~element'
-b({ mod: 'value' }); // 'block block-mod-value'
+b({ mod: 'value' }); // 'block block--mod-value'
 ```
 
 ```js

--- a/src/bem-cn.js
+++ b/src/bem-cn.js
@@ -20,7 +20,8 @@
 		settings = {
 			ns: '',
 			el: '__',
-			mod: '_'
+			mod: '_',
+			modValue: '_'
 		};
 
 	/**
@@ -59,6 +60,8 @@
 			separator = settings.mod;
 		}
 
+		var modValueSeparator = settings.modValue;
+
 		return Object.keys(obj).reduce(function(array, key) {
 			var value = obj[key];
 
@@ -69,7 +72,8 @@
 			if ( value === true ) {
 				array.push(separator + key);
 			} else {
-				array.push(separator + key + separator + value);
+				// Makes block__elem_{modifierKey}_{modifierValue}
+				array.push(separator + key + modValueSeparator + value);
 			}
 
 			return array;

--- a/test/test.js
+++ b/test/test.js
@@ -165,7 +165,8 @@ describe('Setup custom settings', function() {
 		block.setup({
 			ns: 'ns-',
 			el: '~~',
-			mod: '-',
+			mod: '--',
+			modValue: '-'
 		});
 
 		var b = block('block');
@@ -175,12 +176,12 @@ describe('Setup custom settings', function() {
 		).equal('ns-block~~element');
 		should(
 			b({ mod: 'value' }).toString()
-		).equal('ns-block ns-block-mod-value');
+		).equal('ns-block ns-block--mod-value');
 		should(
 			b({ mod: true }).toString()
-		).equal('ns-block ns-block-mod');
+		).equal('ns-block ns-block--mod');
 		should(
 			b('element', { mod: 'value' }).toString()
-		).equal('ns-block~~element ns-block~~element-mod-value');
+		).equal('ns-block~~element ns-block~~element--mod-value');
 	});
 });


### PR DESCRIPTION
Sometimes it's really useful to have an opportunity to tune CSS class representation by separating modifier name/value with custom set of characters.