### PR TITLE
Add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 /.npmignore
 /.gitignore
+/.babelrc
 /.travis.yml
 /webpack.config.js
 /test/


### PR DESCRIPTION
My project is depends on `bem-cn`, and build fails, because my `.babelrc` config inherited `bem-cn` config with plugins section. Babel tries to include `add-module-exports` and fails with error:

```
ERROR in ./~/project/~/bem-cn/dist/bem-cn.js
Module build failed: ReferenceError: Unknown plugin "add-module-exports" specified in "/Users/user/project/node_modules/elements-ui/node_modules/bem-cn/.babelrc" at 0, attempted to resolve relative to "/Users/user/project/node_modules/elements-ui/node_modules/bem-cn"
```

Can you update npm module?

