### PR TITLE
Proposal: Add the ability to drop the modifier name

### DIFF
--- a/src/bem-cn.js
+++ b/src/bem-cn.js
@@ -35,6 +35,7 @@ let defaultSettings = {
 		el: '__',
 		mod: '_',
 		modValue: '_',
+		dropMod: false,
 		classMap: null
 	},
 	// Settings object is global on module level
@@ -83,6 +84,9 @@ function toString(settings, context) {
 					// Modifier with only name
 					if (value === true) {
 						return name + settings.mod + key;
+					// Modifier with only value
+					} else if (settings.dropMod === true) {
+						return name + settings.mod + value;
 					// Modifier with name and value
 					} else {
 						return name + settings.mod + key + settings.modValue + value;

--- a/test/bem-cn.spec.js
+++ b/test/bem-cn.spec.js
@@ -3,6 +3,8 @@ import block from './../src/bem-cn';
 import {ERROR_BLOCK_NAME_TYPE, ERROR_BLOCK_NAME_EMPTY} from './../src/constants';
 
 describe('Wrapper function block', () => {
+	after(block.reset);
+
 	it('should be a function', () => {
 		should(block).be.an.instanceOf(Function);
 	});
@@ -17,6 +19,8 @@ describe('Wrapper function block', () => {
 });
 
 describe('Block output', () => {
+	after(block.reset);
+
 	it('should be a given block name', () => {
 		let b = block('button');
 
@@ -38,6 +42,8 @@ describe('Block output', () => {
 });
 
 describe('Block name', () => {
+	after(block.reset);
+
 	it('should be a string', () => {
 		should(() => {
 			block();
@@ -72,6 +78,8 @@ describe('Block name', () => {
 });
 
 describe('Selector function', () => {
+	after(block.reset);
+
 	it('should return elements class name', () => {
 		let b = block('parent');
 
@@ -179,6 +187,8 @@ describe('Selector function', () => {
 });
 
 describe('Unexpected arguments', () => {
+	after(block.reset);
+
 	it('should be silent when passed unexpected value', () => {
 		let b = block('block');
 
@@ -195,6 +205,8 @@ describe('Unexpected arguments', () => {
 });
 
 describe('Method state()', () => {
+	after(block.reset);
+
 	it('should set states', () => {
 		let b = block('block');
 
@@ -220,6 +232,8 @@ describe('Method state()', () => {
 });
 
 describe('Method is()', () => {
+	after(block.reset);
+
 	it('should set states with is- prefix', () => {
 		let b = block('block');
 
@@ -245,6 +259,8 @@ describe('Method is()', () => {
 });
 
 describe('Method has()', () => {
+	after(block.reset);
+
 	it('should set states with has- prefix', () => {
 		let b = block('block');
 
@@ -270,6 +286,8 @@ describe('Method has()', () => {
 });
 
 describe('Method setup()', () => {
+	after(block.reset);
+
 	it('should set custom settings', () => {
 		block.setup({
 			ns: 'ns-',
@@ -296,6 +314,8 @@ describe('Method setup()', () => {
 });
 
 describe('Method reset()', () => {
+	after(block.reset);
+
 	it('should reset custom settings', () => {
 		block.setup({
 			ns: 'ns-',
@@ -319,6 +339,8 @@ describe('Method reset()', () => {
 });
 
 describe('Method split()', () => {
+	after(block.reset);
+
 	it('should work as String.prototype.split', () => {
 		let b = block('block');
 
@@ -330,6 +352,8 @@ describe('Method split()', () => {
 });
 
 describe('Call without arguments', () => {
+	after(block.reset);
+
 	it('should return the same as toString()', () => {
 		let b = block('block');
 
@@ -364,7 +388,10 @@ describe('Block with class mapping', () => {
 	);
 
 	after(
-		() => block.setup({classMap: null})
+		() => {
+			block.setup({classMap: null});
+			block.reset();
+		}
 	);
 
 	it('should return class for block name', () => {

--- a/test/bem-cn.spec.js
+++ b/test/bem-cn.spec.js
@@ -310,6 +310,15 @@ describe('Method setup()', () => {
 		should(
 			b('element', {mod: 'value'}).toString()
 		).equal('ns-block~~element ns-block~~element--mod-value');
+
+		block.reset();
+		block.setup({
+			mod: '--',
+			dropMod: true
+		});
+		should(
+			b('element', {mod: 'value'}).toString()
+		).equal('block__element block__element--value');
 	});
 });
 


### PR DESCRIPTION
Added a setting called `dropMod` (can be changed, tried to keep with the `mod`/`modValue` convention), which doesn't output the modifier name/`key`.

Eg with `dropMod` enabled `b('block')({position: 'left')` would become just `.block--left` instead of `.block--position_left`

My use case is as I'm looping through `['left', 'right', 'offset']` I want to be able to set `props.b('ball', { position: pos })` and generate `.dual-selector__ball--left`

This is kinda inspired by switching over from [bem-classnames](https://github.com/pocotan001/bem-classnames), in which I was doing

```
const ballClass = {
  name: 'dual-selector__ball',
  modifiers: ['position'],
};
cx(ballClass, {position: pos})
-> .dual-selector__ball--left
```

I'm maybe missing the point here and going about it completely wrong. I'm aware I could set `left: true` but that would require setting `right` and `offset` to false and doing equality checks, which isn't too bad for looping 3 items would get annoying with some more.

To get the tests working I had to reset them after each describe block as the settings seemed to be leaking through as it wasn't using a separate instance each time
