### PR TITLE
ES2015 modules and pkg.module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.3",
   "description": "Friendly BEM class names generator, greate for React",
   "main": "dist/bem-cn.js",
+  "module": "src/bem-cn.js",
   "scripts": {
     "test": "mocha test",
     "lint": "eslint src/ test/ --ext .js",


### PR DESCRIPTION
Tools like Rollup and Webpack 2 support a new entry in the _package.json_ file named _module_:
https://github.com/rollup/rollup/wiki/pkg.module
The value of _module_ should point to a file that uses ES2015 modules, which in the case of bem-cn is _src/bem-cn.js_.

With this change in place, the minified (unzipped) filesize, when using Rollup, went from 3.29 Kb to 1.96 Kb, thus reducing the size from 40%.