### PR TITLE
Server-side rendering causes an error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,10 @@ var config = {
         library: 'block',
         libraryTarget: 'umd',
         filename: 'index.js',
-        path: path.resolve(__dirname, 'lib')
+        path: path.resolve(__dirname, 'lib'),
+
+        // https://github.com/webpack/webpack/issues/6525
+        globalObject: 'this'
     }
 };
 


### PR DESCRIPTION
This PR fixes a reference error when using the package with server-side rendering (https://github.com/webpack/webpack/issues/6642).

```
ReferenceError: window is not defined
```